### PR TITLE
Feature/new logger connectitvity standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # **VMware vCenter Cloud Provider Shell 2G**
 
-Release date: February 2022
+Release date: August 2023
 
-`Shell version: 4.1.0`
+`Shell version: 6.1.0`
 
 `Document version: 2.0`
 
@@ -29,7 +29,7 @@ CloudShell Cloud Providers shells provide L2 or L3 connectivity between resource
 ### VMware vCenter Cloud Provider Shell 2G
 VMware vCenter Cloud Provider Shell 2G provides you with app deployment and management capabilities. 
 These include the following:
-* Python 3.7 support
+* Python 3.9 support
 * vSphere 7 support
 * VM Customization Specifications
 * Standard vSwitch connectivity
@@ -99,11 +99,10 @@ Download the files into a temporary location on your local machine.
 
 The shell comprises:
 
-|File name|Description|
-|:---|:---|
-|VMware vCenter Cloud Provider Shell 2G.zip|Device shell package|
-|cloudshell-VMware-vCenter-Cloud-Provider-Shell-2G-dependencies-win32-package-3.3.0.zip,<br>cloudshell-VMware-vCenter-Cloud-Provider-Shell-2G-dependencies-linux-package-3.3.0.zip|Shell Python dependencies (for offline deployments only)|
-|vCenter.VLAN.Port.Group.zip|Service package for VLAN connections to an existing port group|
+| File name                                                                                  |Description|
+|:-------------------------------------------------------------------------------------------|:---|
+| VMware vCenter Cloud Provider Shell 2G.zip                                                 |Device shell package|
+| cloudshell-VMware-vCenter-Cloud-Provider-Shell-2G-dependencies-win-package-\<version\>.zip |Shell Python dependencies (for offline deployments only)|
 
 # Importing and Configuring the Shell
 This section describes how to import the VMware vCenter Cloud Provider Shell 2G shell and configure and modify the shell’s devices.

--- a/shell-definition.yaml
+++ b/shell-definition.yaml
@@ -90,7 +90,7 @@ node_types:
         description: "The datacenter within the vCenter that will be used for VM deployment. All other settings of this vCenter resource should refer to entities associated with this datacenter."
       Default dvSwitch:
         type: string
-        description: "The default vCenter vSwitch or dvSwitch that will be used when configuring VM connectivity. Should be under the Default Datacenter."
+        description: "The default vCenter vSwitch or dvSwitch that will be used when configuring VM connectivity. Should be under the Default Datacenter. For proper vSwitch connectivity every host in the cluster should have a vSwitch with the same name."
       Holding Network:
         type: string
         description: "The default network that will be configured when disconnecting from another network. Should be under the Default Datacenter."

--- a/shell-definition.yaml
+++ b/shell-definition.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: tosca_simple_yaml_1_0
 metadata:
   template_name: VMware vCenter Cloud Provider Shell 2G
   template_author: Quali
-  template_version: 6.0.2
+  template_version: 6.1.0
   template_icon: shell-icon.png
 
 description: >

--- a/src/driver.py
+++ b/src/driver.py
@@ -109,7 +109,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             logger.info("Starting Autoload command")
             api = CloudShellSessionContext(context).get_api()
             resource_config = VCenterResourceConfig.from_context(context, api=api)
-
             autoload_flow = VCenterAutoloadFlow(resource_config)
             return autoload_flow.discover()
 

--- a/src/driver.py
+++ b/src/driver.py
@@ -14,6 +14,7 @@ from cloudshell.shell.core.session.logging_session import LoggingSessionContext
 from cloudshell.shell.flows.connectivity.parse_request_service import (
     ParseConnectivityRequestService,
 )
+from cloudshell.shell.standards.core.utils import split_list_of_values
 
 from cloudshell.cp.vcenter.flows import (
     SnapshotFlow,
@@ -54,7 +55,6 @@ from cloudshell.cp.vcenter.models.deployed_app import (
     VMFromVMDeployedApp,
 )
 from cloudshell.cp.vcenter.resource_config import VCenterResourceConfig
-from cloudshell.cp.vcenter.utils.split_list_of_values import split_list_of_values
 
 if TYPE_CHECKING:
     from cloudshell.shell.core.driver_context import (

--- a/src/driver.py
+++ b/src/driver.py
@@ -110,7 +110,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             api = CloudShellSessionContext(context).get_api()
             resource_config = VCenterResourceConfig.from_context(context, api=api)
 
-            autoload_flow = VCenterAutoloadFlow(resource_config, logger)
+            autoload_flow = VCenterAutoloadFlow(resource_config)
             return autoload_flow.discover()
 
     def Deploy(
@@ -141,7 +141,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
                 reservation_info=reservation_info,
                 cs_api=api,
                 cancellation_manager=cancellation_manager,
-                logger=logger,
             )
             return deploy_flow.deploy(request_actions=request_actions)
 
@@ -158,9 +157,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             resource_config = VCenterResourceConfig.from_context(context, api=api)
             resource = context.remote_endpoints[0]
             actions = VCenterDeployedVMActions.from_remote_resource(resource, api)
-            return VCenterPowerFlow(
-                actions.deployed_app, resource_config, logger
-            ).power_on()
+            return VCenterPowerFlow(actions.deployed_app, resource_config).power_on()
 
     def PowerOff(self, context: ResourceRemoteCommandContext, ports: list[str]):
         """Called during sandbox's teardown.
@@ -175,9 +172,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             resource_config = VCenterResourceConfig.from_context(context, api=api)
             resource = context.remote_endpoints[0]
             actions = VCenterDeployedVMActions.from_remote_resource(resource, api)
-            return VCenterPowerFlow(
-                actions.deployed_app, resource_config, logger
-            ).power_off()
+            return VCenterPowerFlow(actions.deployed_app, resource_config).power_off()
 
     def PowerCycle(
         self, context: ResourceRemoteCommandContext, ports: list[str], delay
@@ -188,7 +183,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             resource_config = VCenterResourceConfig.from_context(context, api=api)
             resource = context.remote_endpoints[0]
             actions = VCenterDeployedVMActions.from_remote_resource(resource, api)
-            power_flow = VCenterPowerFlow(actions.deployed_app, resource_config, logger)
+            power_flow = VCenterPowerFlow(actions.deployed_app, resource_config)
             power_flow.power_off()
             time.sleep(float(delay))
             power_flow.power_on()
@@ -215,10 +210,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             actions = VCenterDeployedVMActions.from_remote_resource(resource, api)
             cancellation_manager = CancellationContextManager(cancellation_context)
             return refresh_ip(
-                actions.deployed_app,
-                resource_config,
-                cancellation_manager,
-                logger,
+                actions.deployed_app, resource_config, cancellation_manager
             )
 
     def GetVmDetails(
@@ -243,7 +235,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             cancellation_manager = CancellationContextManager(cancellation_context)
             actions = VCenterGetVMDetailsRequestActions.from_request(requests, api)
             return VCenterGetVMDetailsFlow(
-                resource_config, cancellation_manager, logger
+                resource_config, cancellation_manager
             ).get_vm_details(actions)
 
     def ApplyConnectivityChanges(self, context: ResourceCommandContext, request: str):
@@ -258,10 +250,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
                 connectivity_model_cls=VcenterConnectivityActionModel,
             )
             return VCenterConnectivityFlow(
-                resource_config,
-                reservation_info,
-                parse_connectivity_req_service,
-                logger,
+                parse_connectivity_req_service, resource_config, reservation_info
             ).apply_connectivity(request)
 
     def DeleteInstance(self, context: ResourceRemoteCommandContext, ports: list[str]):
@@ -277,9 +266,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             resource = context.remote_endpoints[0]
             actions = VCenterDeployedVMActions.from_remote_resource(resource, api)
             reservation_info = ReservationInfo.from_remote_resource_context(context)
-            delete_instance(
-                actions.deployed_app, resource_config, reservation_info, logger
-            )
+            delete_instance(actions.deployed_app, resource_config, reservation_info)
 
     def SaveApp(
         self,
@@ -294,7 +281,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             cancellation_manager = CancellationContextManager(cancellation_context)
             actions = SaveRestoreRequestActions.from_request(request)
             return SaveRestoreAppFlow(
-                resource_config, api, cancellation_manager, logger
+                resource_config, api, cancellation_manager
             ).save_apps(actions.save_app_actions)
 
     def DeleteSavedApps(
@@ -310,7 +297,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             cancellation_manager = CancellationContextManager(cancellation_context)
             actions = SaveRestoreRequestActions.from_request(request)
             return SaveRestoreAppFlow(
-                resource_config, api, cancellation_manager, logger
+                resource_config, api, cancellation_manager
             ).delete_saved_apps(actions.delete_saved_app_actions)
 
     def remote_save_snapshot(
@@ -330,7 +317,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             return SnapshotFlow(
                 resource_config,
                 actions.deployed_app,
-                logger,
             ).save_snapshot(snapshot_name, save_memory)
 
     def remote_restore_snapshot(
@@ -349,7 +335,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             return SnapshotFlow(
                 resource_config,
                 actions.deployed_app,
-                logger,
             ).restore_from_snapshot(api, snapshot_name)
 
     def remote_get_snapshots(
@@ -365,7 +350,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             return SnapshotFlow(
                 resource_config,
                 actions.deployed_app,
-                logger,
             ).get_snapshot_paths()
 
     def remote_remove_snapshot(
@@ -384,7 +368,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             return SnapshotFlow(
                 resource_config,
                 actions.deployed_app,
-                logger,
             ).remove_snapshot(snapshot_name, remove_child)
 
     def orchestration_save(
@@ -403,7 +386,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             return SnapshotFlow(
                 resource_config,
                 actions.deployed_app,
-                logger,
             ).orchestration_save()
 
     def orchestration_restore(
@@ -421,7 +403,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             return SnapshotFlow(
                 resource_config,
                 actions.deployed_app,
-                logger,
             ).orchestration_restore(saved_details, api)
 
     def get_vm_uuid(self, context: ResourceCommandContext, vm_name: str) -> str:
@@ -429,7 +410,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             logger.info("Starting Get VM UUID command")
             api = CloudShellSessionContext(context).get_api()
             resource_config = VCenterResourceConfig.from_context(context, api=api)
-            return get_vm_uuid_by_name(resource_config, vm_name, logger)
+            return get_vm_uuid_by_name(resource_config, vm_name)
 
     def get_cluster_usage(
         self, context: ResourceCommandContext, datastore_name: str
@@ -438,7 +419,7 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             logger.info("Starting Get Cluster Usage command")
             api = CloudShellSessionContext(context).get_api()
             resource_config = VCenterResourceConfig.from_context(context, api=api)
-            return get_cluster_usage(resource_config, datastore_name, logger)
+            return get_cluster_usage(resource_config, datastore_name)
 
     def reconfigure_vm(
         self,
@@ -460,7 +441,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
                 cpu,
                 ram,
                 hdd,
-                logger,
             )
 
     def get_vm_web_console(
@@ -472,21 +452,21 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             resource_config = VCenterResourceConfig.from_context(context, api=api)
             resource = context.remote_endpoints[0]
             actions = VCenterDeployedVMActions.from_remote_resource(resource, api)
-            return get_vm_web_console(resource_config, actions.deployed_app, logger)
+            return get_vm_web_console(resource_config, actions.deployed_app)
 
     def get_attribute_hints(self, context: ResourceCommandContext, request: str) -> str:
         with LoggingSessionContext(context) as logger:
             logger.info("Starting Get attribute hints command")
             api = CloudShellSessionContext(context).get_api()
             resource_config = VCenterResourceConfig.from_context(context, api=api)
-            return get_hints(resource_config, request, logger)
+            return get_hints(resource_config, request)
 
     def validate_attributes(self, context: ResourceCommandContext, request: str) -> str:
         with LoggingSessionContext(context) as logger:
             logger.info("Starting Validate attributes command")
             api = CloudShellSessionContext(context).get_api()
             resource_config = VCenterResourceConfig.from_context(context, api=api)
-            return validate_attributes(resource_config, request, logger)
+            return validate_attributes(resource_config, request)
 
     def customize_guest_os(
         self,
@@ -508,7 +488,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
                 custom_spec_name,
                 custom_spec_params,
                 override_custom_spec,
-                logger,
             )
 
     def add_vm_to_affinity_rule(
@@ -522,8 +501,6 @@ class VMwarevCenterCloudProviderShell2GDriver(ResourceDriverInterface):
             api = CloudShellSessionContext(context).get_api()
             resource_config = VCenterResourceConfig.from_context(context, api=api)
             reservation_info = ReservationInfo.from_resource_context(context)
-            flow = AffinityRulesFlow(
-                resource_config, reservation_info.reservation_id, logger
-            )
+            flow = AffinityRulesFlow(resource_config, reservation_info.reservation_id)
             vm_uuids = list(split_list_of_values(vm_uuids))
             return flow.add_vms_to_affinity_rule(vm_uuids, affinity_rule_name)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-cloudshell-shell-core~=5.0
+cloudshell-shell-core~=6.0
 cloudshell-cp-core~=2.4
-cloudshell-cp-vcenter>=5.0.2,<6
+cloudshell-cp-vcenter~=6.0


### PR DESCRIPTION
- use CS logging v2
- use connectivity flow v4
  - support manual and auto interfaces in a connector at the same time
  - remove network tags only for static shell. In other cases they would be deleted in DeleteInstance command when sandbox is finishing
  - get tags before deleting networks, remove tags after all networks is deleted
- delete tags of VM and folder after the objects are removed
- use "Existing Network" attribute